### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-#test
+#test2
 kind: Deployment
 metadata:
   name: {{ include "mailhog.fullname" . }}


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
