### PR TITLE
Update values.yaml

### DIFF
--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -1,3 +1,4 @@
+#test
 image:
   repository: docker.io/mailhog/mailhog
   tag: ""


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
